### PR TITLE
Update for 6.3

### DIFF
--- a/HeelsPlugin/HeelsPlugin.csproj
+++ b/HeelsPlugin/HeelsPlugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>1.2.5</Version>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/HeelsPlugin/HeelsPlugin.json
+++ b/HeelsPlugin/HeelsPlugin.json
@@ -7,6 +7,6 @@
   "RepoUrl": "https://github.com/LeonBlade/HeelsPlugin",
   "ApplicableVersion": "any",
   "Tags": ["heels", "high heels", "height", "offset", "leonblade"],
-  "DalamudApiLevel": 7,
+  "DalamudApiLevel": 8,
   "IconUrl": "https://github.com/LeonBlade/HeelsPlugin/raw/main/icon.png"
 }

--- a/HeelsPlugin/PluginMemory.cs
+++ b/HeelsPlugin/PluginMemory.cs
@@ -189,7 +189,7 @@ namespace HeelsPlugin
     {
       try
       {
-        var modelPtr = Marshal.ReadInt64(actor, 0xF0);
+        var modelPtr = Marshal.ReadInt64(actor, 0x100);
         if (modelPtr == 0)
           return (IntPtr.Zero, Vector3.Zero);
         var positionPtr = new IntPtr(modelPtr + 0x50);


### PR DESCRIPTION
This PR bumps the .NET version to 7 and the Dalamud API Level to 8, as required by the latest Dalamud update, and fixes the player model offset that changed with 6.3 (shifted from 0xF0 to 0x100)