### PR TITLE
Fix for release CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           name: ${{ env.PROJECT_NAME }} ${{ steps.tag.outputs.tag }}
           tag_name: ${{ steps.tag.outputs.tag }}
           body: ${{ github.events.commits[0].message }}
-          files: ${{ steps.download.outputs.download-path }}/HeelsPlugin.zip
+          files: ./HeelsPlugin.zip
 
       - name: Trigger plugin repo update
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
A dependency of `softprops/action-gh-release` broke non-POSIX filepaths. Annoying, but the artifact goes to the current working directory so this is a quick and easy workaround.