### PR TITLE
Apply on IPC assign

### DIFF
--- a/HeelsPlugin/IpcManager.cs
+++ b/HeelsPlugin/IpcManager.cs
@@ -32,6 +32,7 @@ namespace HeelsPlugin
       RegisterPlayer.RegisterAction((gameObject, offset) =>
       {
         memory.PlayerOffsets[gameObject] = offset;
+        memory.SetPosition(gameObject.Position.Y + offset, gameObject.Address, true);
       });
 
       UnregisterPlayer.RegisterAction((gameObject) =>


### PR DESCRIPTION
Applies the offset assigned by IPC to the character as soon as it is received, removing the need for players to move to have their offsets assigned